### PR TITLE
fix: replace placeholder handlePagination with a no-op default prop f…

### DIFF
--- a/client/app/components/Table/AdminTable.jsx
+++ b/client/app/components/Table/AdminTable.jsx
@@ -143,8 +143,7 @@ function CustomTable({ ...props }) {
 
 CustomTable.defaultProps = {
   tableHeaderColor: 'gray',
-  handlePagination: () =>
-    console.log('todo: make handlePagination function!!!'),
+  handlePagination: () => {},
 };
 
 CustomTable.propTypes = {

--- a/client/app/components/Table/NewTable.jsx
+++ b/client/app/components/Table/NewTable.jsx
@@ -422,8 +422,7 @@ function CustomTable({
 
 CustomTable.defaultProps = {
   tableHeaderColor: 'gray',
-  handlePagination: () =>
-    console.log('todo: make handlePagination function!!!'),
+  handlePagination: () => {},
 };
 
 export default CustomTable;

--- a/client/app/components/Table/Table.jsx
+++ b/client/app/components/Table/Table.jsx
@@ -143,8 +143,7 @@ function CustomTable({ ...props }) {
 
 CustomTable.defaultProps = {
   tableHeaderColor: 'gray',
-  handlePagination: () =>
-    console.log('todo: make handlePagination function!!!'),
+  handlePagination: () => {},
 };
 
 CustomTable.propTypes = {


### PR DESCRIPTION
We replaced the placeholder console warning console.log('todo: make handlePagination function!!!') inside Table.jsx, NewTable.jsx, and AdminTable.jsx with a clean, standard no-operation function () => {} in CustomTable.defaultProps. This removes the log warning while preserving normal component behavior for parent components that manage pagination state.