### PR TITLE
fix: replace deprecated Model.remove with deleteMany

### DIFF
--- a/server/modules/bug/bugController.js
+++ b/server/modules/bug/bugController.js
@@ -52,7 +52,7 @@ bugController.DeleteError = async (req, res, next) => {
 };
 bugController.DeleteAll = async (req, res, next) => {
   try {
-    const dels = await bugSch.remove({});
+    const dels = await bugSch.deleteMany({});
     return otherHelper.sendResponse(res, httpStatus.OK, true, null, null, 'all errors deleted!', null);
   } catch (err) {
     next(err);


### PR DESCRIPTION
Issue Description
In 

bugController.js:L55
, the controller was calling bugSch.remove({}) to delete all error logs. However, Model.remove() is deprecated and was completely removed in Mongoose 8.x (which this project uses: "mongoose": "^8.8.3"). Calling this endpoint would throw a runtime error.

Solution Description
We replaced bugSch.remove({}) with the supported bugSch.deleteMany({}) method, resolving the runtime crash.

